### PR TITLE
Fix image and size lookups

### DIFF
--- a/lib/Tokamak/Command/create.pm
+++ b/lib/Tokamak/Command/create.pm
@@ -47,7 +47,7 @@ sub validate_args {
   }
 
   if ( $opt->{image}) {
-    $opt->{image_uuid} = Tokamak::Command::images::get_uuid_from_name( $opt->{type} );
+    $opt->{image_uuid} = Tokamak::Command::images::get_uuid_from_name( $opt->{image} );
   }
   else {
     $opt->{image_uuid} = Tokamak::Command::images::default_image( $opt->{type} );
@@ -76,7 +76,6 @@ sub chef_bootstrap {
   print "% CHEF bootstrap: role:$role\n";
   print "% CHEF bootstrap: chef_env:$chef_env\n";
 
-  
   my ($merged, $exit) = capture_merged {
     system("knife bootstrap $ip -A -E $chef_env -N $alias -x root -F min $knife_role");
   };

--- a/lib/Tokamak/Command/sizes.pm
+++ b/lib/Tokamak/Command/sizes.pm
@@ -62,8 +62,12 @@ sub get_uuid_from_name {
   foreach my $key ( keys %packages ) {
 
     next if $key eq "default_size";
-
+    next if $key eq "kvm";
+    next if $key eq "os";
+    
     if ( exists $packages{$key}{alias} ) {
+      next if $packages{$key}{type} ne $type;
+
       if ( $alias eq $packages{$key}{alias} ) {
         return $key;
       }


### PR DESCRIPTION
If you pass in a image UUID, tokamak previously blew up. This now works. You still can't pass in a name, until `images::get_uuid_from_name` is actually implemented.

If you passed in a size, you'd get the first hit, regardless of the type requested. So if you requested `-t kvm -s large` you would always get the `os` variant of that size. (Which means you'd get _one_ vCPU instead of however many the package actually defined, since native zones don't use vcpus.)